### PR TITLE
fix: 時間格式錯誤

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,16 +1,19 @@
 const CONVERT = {
   stringAddSymbol: (str) => `${str}！`,
   formatDate: (date) => {
-    const formattedDate = new Date(date).toLocaleString('zh-TW', {
+    const formattedDate = new Date(date).toLocaleDateString('zh-TW', {
       year: 'numeric',
       month: '2-digit',
-      day: '2-digit',
+      day: '2-digit'
+    })
+
+    const formattedTime = new Date(date).toLocaleTimeString('zh-TW', {
       hour: '2-digit',
       minute: '2-digit',
       hour12: false
     })
 
-    return formattedDate
+    return `${formattedDate} ${formattedTime}`
   }
 }
 


### PR DESCRIPTION
發生：出現 24:06 情形
原因：判斷是因為 toLocaleString 方法預設使用的時間格式是 12 小時制，而 hour12: false 可能沒有生效
解決方法：拆開日期與時間個別針對做格式化