### PR TITLE
fix: user profile patch / 阻擋非手機號碼

### DIFF
--- a/controllers/userController/index.js
+++ b/controllers/userController/index.js
@@ -174,6 +174,16 @@ exports.profile = {
 
     try {
       const { userId } = req
+
+      const phoneRegex = /^09\d{8}$/ // 以09開頭，後面跟着8個数字
+
+      if (!phone || !phoneRegex.test(phone)) {
+        return res.status(400).json({
+          status: 400,
+          message: '手機號碼格式不正確'
+        })
+      }
+
       const user = await User.findByPk(userId)
 
       if (!user) {


### PR DESCRIPTION
因為:
前台修改 phone 輸入 123123123 送出修改，get api 時，最後會多出一個空格
原因:
migration user table phone colunm 預設為 10 碼，在輸入不足的情況下會自動補足其餘空。
解決方法:
判斷傳入body 的 phone 值，是否為 09 開頭，且滿足10碼。 